### PR TITLE
Allow multiple .psenvrc files with the same contents

### DIFF
--- a/posh-direnv/posh-direnv-auth.ps1
+++ b/posh-direnv/posh-direnv-auth.ps1
@@ -23,9 +23,12 @@ function Compare-DirEnvRc {
         Write-Verbose "Need to initalise allow list"
         [void](Initialize-AllowList)
     }
-    if($global:psenvrcAllowList -ccontains (Get-FileHash $PsEnvRcFile -Algorithm SHA256).Hash -and
-        ((Get-Content (Join-Path $psenvrcAuthDir (Get-FileHash $PsEnvRcFile -Algorithm SHA256).Hash) -First 1) -eq $PsEnvRcFile)) {
-            $rcFileAllowed = $true
+    if($global:psenvrcAllowList -ccontains (Get-FileHash $PsEnvRcFile -Algorithm SHA256).Hash) {
+        foreach($line in (Get-Content (Join-Path $psenvrcAuthDir (Get-FileHash $PsEnvRcFile -Algorithm SHA256).Hash))) {
+            if ($line -eq $PsEnvRcFile) {
+                $rcFileAllowed = $true
+            }
+        }
     }
     return $rcFileAllowed
 }


### PR DESCRIPTION
Currently `Compare-DirEnvRc` only uses the first line of allow list file. It is impossible to approve multiple `.psenvrc` files with the same contents. This change makes the function checks every line of the allow list file and fix this issue.