### PR TITLE
Set-DirEnvRc also looks for .psenvrc file in parents directory

### DIFF
--- a/Install-posh-direnv.ps1
+++ b/Install-posh-direnv.ps1
@@ -1,0 +1,14 @@
+$targetPath = $env:PSModulePath.Split(";")[0]
+
+$moduleName = "posh-direnv"
+
+Remove-Module $moduleName 
+
+if (Test-Path -PathType Container "$targetPath") {
+    Remove-Item -Recurse -Force -Confirm:$false "$targetPath/$moduleName" -ErrorAction SilentlyContinue
+}
+
+Copy-Item -Recurse "$PSScriptRoot/$moduleName" "$targetPath/"
+
+Import-Module $moduleName -Force
+

--- a/posh-direnv/posh-direnv-auth.ps1
+++ b/posh-direnv/posh-direnv-auth.ps1
@@ -1,5 +1,5 @@
 # Managed the allowed .psenvrc file list
-Set-Variable -Name "psenvrcAuthDir" -Value (Join-Path $env:HOME .direnv) -Scope script -Option constant
+Set-Variable -Name "psenvrcAuthDir" -Value (Join-Path $env:UserProfile .direnv) -Scope script -Option constant
 [System.Collections.ArrayList]$global:psenvrcAllowList = @()
 
 function Initialize-AllowList {

--- a/posh-direnv/posh-direnv.ps1
+++ b/posh-direnv/posh-direnv.ps1
@@ -3,17 +3,44 @@ Set-Variable -Name "psenvrcBase" -Value ([string]".psenvrc") -Scope script -Opti
 #
 # https://blogs.msdn.microsoft.com/powershell/2006/07/21/setting-the-console-title-to-be-your-current-working-directory/
 
+function Get-PsEnvRc {
+    [CmdletBinding()]
+    Param(
+        $Path
+    )
+    $envPath = $Path
+    $p = $null
+    while ($true) {
+        $p = (Resolve-Path (Join-Path $envPath $psenvrcBase) -ErrorAction SilentlyContinue).Path
+        if ($p) { return $p }
+        $parentPath = Split-Path $envPath -Parent
+        if ($parentPath) { 
+            $envPath = $parentPath
+        } else {
+            return $null
+        }
+    }
+}
+
 function Set-DirEnvRc {
     [CmdletBinding()]
     Param(
         [switch]$Force
     )
-    $p = (Resolve-Path (Join-Path $pwd $psenvrcBase) -ErrorAction SilentlyContinue).Path
+
+    $p = Get-PsEnvRc($pwd)
+
+    if ($p) {
+        $pDir = Split-Path $p -Parent
+        Write-Verbose "$(Join-Path $pDir $psenvrcBase) found"
+    } else {
+        $pDir = $pwd
+    }
 
     if (Test-Path Env:PSDIRENV_DIR) {
         Write-Verbose "PSDIRENV_DIR is set"
-        if ( -Not $pwd.Path.ToLower().StartsWith($env:PSDIRENV_DIR.ToLower()) -or
-            ($p -and $env:PSDIRENV_DIR -ne $pwd)) {
+        if ( -Not $pDir.ToString().ToLower().StartsWith($env:PSDIRENV_DIR.ToLower()) -or
+            ($p -and $env:PSDIRENV_DIR -ne $pDir)) {
             Write-Verbose "Moved out of tree or new env requested"
             if(-Not $p) {
                 Write-Host "psdirenv: unloading"
@@ -37,12 +64,12 @@ function Set-DirEnvRc {
     }
 
     if (-not $p) {
-        Write-Verbose "$pwd\$psenvrcBase not find"
+        Write-Verbose "$(Join-Path $pDir $psenvrcBase) not found"
         return
     }
 
-    if (-not $Force -and $env:PSDIRENV_DIR -eq $pwd) {
-        Write-Verbose "$p already applyed"
+    if (-not $Force -and $env:PSDIRENV_DIR -eq $pDir) {
+        Write-Verbose "$p already applied"
         return
     }
 
@@ -58,7 +85,8 @@ function Set-DirEnvRc {
         $diffs.remove = $diff | Where-Object -Property SideIndicator -CEQ "=>" | Where-Object { $_.Name -notin $present }
         Write-Host "psenvdir: export " -NoNewLine
         Write-Host (@(($diffs.remove | Select-Object -ExpandProperty Name | ForEach-Object {"+$($_)"})) + ($diffs.changed | Select-Object -ExpandProperty Name | ForEach-Object {"~$($_)"}))
-        Set-Item -Path Env:PSDIRENV_DIR -Value $pwd.Path
+        Write-Host "psenvdir: setting path $pDir"
+        Set-Item -Path Env:PSDIRENV_DIR -Value $pDir
         $diffs = $diffs | ConvertTo-Json -Compress
         $bytes = [System.Text.Encoding]::Unicode.GetBytes($diffs)
         $diffs = [Convert]::ToBase64String($bytes)

--- a/posh-direnv/posh-direnv.psm1
+++ b/posh-direnv/posh-direnv.psm1
@@ -7,7 +7,7 @@ Get-ChildItem "$PSScriptRoot/*.ps1" |
 ## Prompt Adjustment ##########################################################
 
 if (Test-Path Function:\PromptBackup) {
-    Write-Host "Backup Prompt function name is duplicationed" -ForegroundColor Cyan
+    Write-Host "Backup Prompt function name is duplicated" -ForegroundColor Cyan
 }
 
 if (Test-Path Function:\Prompt) {
@@ -25,6 +25,10 @@ function global:Prompt {
     }
     catch {
         Write-Host "Error in .psenvrc. $($_.Exception.Message) >" -ForegroundColor Red
+        # Fall back on existing Prompt function
+        if (Test-Path Function:\PromptBackup) {
+            PromptBackup
+        }
     }
 }
 


### PR DESCRIPTION
This allowa having two directories with .psenvrc in it and no matter in witch sub directory I am, if I change to the other directory (even a deep inside one), Set-DirEnvRc will look first in current dir, then in parent until it finds .psenvrc.
This allows me to have one production folder and a dev folder and stay confident that if I change dirs, settings will change no matter in witch directory inside of the folder I am.